### PR TITLE
Update Arch Linux to 2020.08.01

### DIFF
--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/arch/archlinux-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/arch/boot/x86_64/vmlinuz img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
-    initrd (loop)/arch/boot/intel_ucode.img (loop)/arch/boot/amd_ucode.img (loop)/arch/boot/x86_64/archiso.img
+    linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
+    initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/archiso.img
   }
 done


### PR DESCRIPTION
Kernel and microcode image filenames changed in `archlinux-2020.08.01-x86_64.iso`.
See https://gitlab.archlinux.org/archlinux/archiso/-/commit/47e11125e4672fc3448caefa6728439160daedd3.