### PR TITLE
Update Arch Linux config

### DIFF
--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/arch/archlinux-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/arch/boot/x86_64/vmlinuz img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
-    initrd (loop)/arch/boot/intel_ucode.img (loop)/arch/boot/amd_ucode.img (loop)/arch/boot/x86_64/archiso.img
+    linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
+    initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/initramfs-linux.img
   }
 done


### PR DESCRIPTION
It looks like the layout of the Arch ISOs have changed slightly since the creation of the Arch config. This will correct it to work with the new ISOs. 