### PR TITLE
Update grub configuration for Arch Linux

### DIFF
--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/arch/archlinux-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/arch/boot/x86_64/vmlinuz img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
-    initrd (loop)/arch/boot/intel_ucode.img (loop)/arch/boot/amd_ucode.img (loop)/arch/boot/x86_64/archiso.img
+    linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop="${isofile}" earlymodules=loop
+    initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/initramfs-linux.img
   }
 done


### PR DESCRIPTION
Based on this wiki [[Multiboot USB drive](https://wiki.archlinux.org/title/Multiboot_USB_drive)], Arch has been updated their ISO structure that makes me couldn't boot into archiso, with this update i can boot into archiso again