### PR TITLE
Avoid "Please remove the live-medium" logic in recent debian

### DIFF
--- a/grub2/inc-debian.cfg
+++ b/grub2/inc-debian.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/debian/debian-live-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/live/vmlinuz-* boot=live findiso=${isofile} components
+    linux (loop)/live/vmlinuz-* boot=live findiso=${isofile} components noeject
     initrd (loop)/live/initrd.img-*
   }
 done


### PR DESCRIPTION
There is a bug in debian related to "findiso" kernel option: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1028627

This fix makes sure debian (10, 11, 12) treats itself as NOT booted from a removable media when used with glim.