### PR TITLE
Skip filesystem check in ubuntu flavours

### DIFF
--- a/grub2/inc-kubuntu.cfg
+++ b/grub2/inc-kubuntu.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/kubuntu/kubuntu-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} quiet splash
+    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
 done

--- a/grub2/inc-ubuntu.cfg
+++ b/grub2/inc-ubuntu.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/ubuntu/ubuntu-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} quiet splash
+    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
 done

--- a/grub2/inc-xubuntu.cfg
+++ b/grub2/inc-xubuntu.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/xubuntu/xubuntu-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} quiet splash
+    linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
 done


### PR DESCRIPTION
Important: "fsck.mode=skip" should not be the last in the list of kernel options. There was a bug in casper when the option is not applied if it is the last one: https://bugs.launchpad.net/ubuntu/+source/casper/+bug/1892369