### PR TITLE
Check if the loop device already exists before creating one

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -25,6 +25,12 @@ export isopath
 export rootuuid
 export theme
 
+# Like 'loopback loop A', but check if (loop) already exists
+function loop {
+  if [ -e (loop) ]; then loopback -d loop; fi
+  loopback loop "$1"
+}
+
 # Menu!
 # We (ab)use 'for' to check for at least one ISO file to show the menu entry
 

--- a/grub2/inc-almalinux.cfg
+++ b/grub2/inc-almalinux.cfg
@@ -19,7 +19,7 @@ for isofile in $isopath/almalinux/AlmaLinux-*.iso; do
       linuxlaunch=''
     fi
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     if [ ${versionmaj} -ge 9 ]; then
       linux${linuxlaunch} (loop)/isolinux/vmlinuz0 root=live:CDLABEL=${isolabel} rd.live.image quiet rhgb rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}

--- a/grub2/inc-antix.cfg
+++ b/grub2/inc-antix.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/antix/antiX-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/antiX/vmlinuz fromiso=${isofile} from=all buuid=${rootuuid} quiet splash=v disable=lx
     initrd (loop)/antiX/initrd.gz
   }

--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/arch/archlinux-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop="${isofile}" earlymodules=loop
     initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/initramfs-linux.img
   }

--- a/grub2/inc-artix.cfg
+++ b/grub2/inc-artix.cfg
@@ -13,7 +13,7 @@ for isofile in $isopath/artix/artix-*.iso; do
       set isofile=$2
       set isoname=$3
       echo "Using ${isoname}..."
-      loopback loop $isofile
+      loop $isofile
       linux (loop)/boot/vmlinuz-x86_64 img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile} lang=en_US keytable=us tz=UTC
       initrd (loop)/boot/intel-ucode.img (loop)/boot/amd-ucode.img (loop)/boot/initramfs-x86_64.img
     }
@@ -22,7 +22,7 @@ for isofile in $isopath/artix/artix-*.iso; do
       set isofile=$2
       set isoname=$3
       echo "Using ${isoname}..."
-      loopback loop $isofile
+      loop $isofile
       linux (loop)/boot/vmlinuz-x86_64 overlay=livefs img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile} lang=en_US keytable=us tz=UTC
       initrd (loop)/boot/intel-ucode.img (loop)/boot/amd-ucode.img (loop)/boot/initramfs-x86_64.img
     }

--- a/grub2/inc-bodhi.cfg
+++ b/grub2/inc-bodhi.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/bodhi/bodhi-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz iso-scan/filename=${isofile} file=/cdrom/preseed/custom.seed boot=casper quiet splash
     initrd (loop)/casper/initrd*
   }

--- a/grub2/inc-centos.cfg
+++ b/grub2/inc-centos.cfg
@@ -16,7 +16,7 @@ for isofile in $isopath/centos/CentOS-*-Live*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/isolinux/vmlinuz0 root=live:CDLABEL=${isolabel} rootfstype=auto ro rd.live.image quiet rhgb rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}
     initrd (loop)/isolinux/initrd0.img

--- a/grub2/inc-clonezilla.cfg
+++ b/grub2/inc-clonezilla.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/clonezilla/clonezilla-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} union=overlay components quiet toram=live,syslinux
     initrd (loop)/live/initrd.img
   }

--- a/grub2/inc-debian.cfg
+++ b/grub2/inc-debian.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/debian/debian-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz-* boot=live findiso=${isofile} components noeject
     initrd (loop)/live/initrd.img-*
   }

--- a/grub2/inc-elementary.cfg
+++ b/grub2/inc-elementary.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/elementary/elementaryos-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} quiet splash
     initrd (loop)/casper/initrd.lz
   }

--- a/grub2/inc-fedora.cfg
+++ b/grub2/inc-fedora.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/fedora/Fedora-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/isolinux/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
     initrd (loop)/isolinux/initrd.img

--- a/grub2/inc-gentoo.cfg
+++ b/grub2/inc-gentoo.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/gentoo/*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/boot/gentoo isoboot=${isofile} nodhcp looptype=squashfs loop=/image.squashfs cdroot docache dokeymap
     initrd (loop)/boot/gentoo.igz
   }

--- a/grub2/inc-gparted.cfg
+++ b/grub2/inc-gparted.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/gparted/gparted-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz boot=live username=user quiet findiso=${isofile} toram=filesystem.squashfs locales=en_US.UTF-8 keyboard-layouts=en_US gl_batch
     initrd (loop)/live/initrd.img
   }
@@ -18,7 +18,7 @@ for isofile in $isopath/gparted/gparted-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz boot=live username=user quiet findiso=${isofile} toram=filesystem.squashfs
     initrd (loop)/live/initrd.img
   }

--- a/grub2/inc-grml.cfg
+++ b/grub2/inc-grml.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/grml/grml*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     set root=(loop)
     set iso_path=$isofile
     export iso_path

--- a/grub2/inc-ipxe.cfg
+++ b/grub2/inc-ipxe.cfg
@@ -9,7 +9,7 @@ for isofile in $isopath/ipxe/ipxe*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux16 (loop)/ipxe.krn
   }
 done

--- a/grub2/inc-kali.cfg
+++ b/grub2/inc-kali.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/kali/kali-linux-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz-*-amd64 findiso=${isofile} boot=live components splash username=root hostname=kali
     initrd (loop)/live/initrd.img-*-amd64
   }
@@ -18,7 +18,7 @@ for isofile in $isopath/kali/kali-linux-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz-*-amd64 findiso=${isofile} boot=live components splash username=root hostname=kali noswap noautomount
     initrd (loop)/live/initrd.img-*-amd64
   }

--- a/grub2/inc-kubuntu.cfg
+++ b/grub2/inc-kubuntu.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/kubuntu/kubuntu-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }

--- a/grub2/inc-linuxmint.cfg
+++ b/grub2/inc-linuxmint.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/linuxmint/linuxmint-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz file=/cdrom/preseed/linuxmint.seed boot=casper iso-scan/filename=${isofile} quiet splash --
     initrd (loop)/casper/initrd.lz
   }
@@ -29,7 +29,7 @@ for isofile in $isopath/linuxmint/lmde-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} live-config live-media-path=/live quiet splash --
     initrd (loop)/live/initrd.lz
   }

--- a/grub2/inc-manjaro.cfg
+++ b/grub2/inc-manjaro.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/manjaro/manjaro-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/boot/vmlinuz-x86_64 img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
     initrd (loop)/boot/intel_ucode.img (loop)/boot/amd_ucode.img (loop)/boot/initramfs-x86_64.img
   }

--- a/grub2/inc-netrunner.cfg
+++ b/grub2/inc-netrunner.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/netrunner/netrunner-*.iso; do
       set isofile=$2
       set isoname=$3
       echo "Using ${isoname}..."
-      loopback loop $isofile
+      loop $isofile
       linux (loop)/live/vmlinuz boot=live hostname=live-pc username=live live-config.user-default-groups=sambashare,cdrom,floppy,audio,dip,video,plugdev,netdev,lpadmin,scanner,bluetooth,adm apparmor=0 quiet splash findiso=${isofile}
       initrd (loop)/live/initrd.img
     }
@@ -21,7 +21,7 @@ for isofile in $isopath/netrunner/netrunner-*.iso; do
       set isofile=$2
       set isoname=$3
       echo "Using ${isoname}..."
-      loopback loop $isofile
+      loop $isofile
       linux (loop)/boot/vmlinuz-x86_64 img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile} misobasedir=netrunner quiet
       initrd (loop)/boot/intel_ucode.img (loop)/boot/initramfs-x86_64.img
     }

--- a/grub2/inc-openbsd.cfg
+++ b/grub2/inc-openbsd.cfg
@@ -28,7 +28,7 @@ for isofile in $isopath/openbsd/*.iso; do
     echo "Using ${isoname} ..."
 #    kernelopts=" ssh=password lang=de "
 #    export kernelopts
-    loopback loop ${isofile}
+    loop ${isofile}
     set root=(loop)
     kopenbsd /${version}/${arch}/bsd.rd
   }

--- a/grub2/inc-peppermint.cfg
+++ b/grub2/inc-peppermint.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/peppermint/Peppermint-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz* file=(loop)/preseed/peppermint.seed boot=casper iso-scan/filename=${isofile} quiet splash
     initrd (loop)/casper/initrd*
   }

--- a/grub2/inc-porteus.cfg
+++ b/grub2/inc-porteus.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/porteus/Porteus-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/boot/syslinux/vmlinuz from=${isofile}
     initrd (loop)/boot/syslinux/initrd.xz
   }

--- a/grub2/inc-rhel.cfg
+++ b/grub2/inc-rhel.cfg
@@ -24,7 +24,7 @@ for isofile in $isopath/rhel/rhel-*-dvd.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isouuid --fs-uuid (loop)
     linux (loop)/isolinux/vmlinuz root=live:UUID=${isouuid} iso-scan/filename=${isofile} inst.repo=file:///run/initramfs/live ${rhelopts}
     initrd (loop)/isolinux/initrd.img
@@ -33,7 +33,7 @@ for isofile in $isopath/rhel/rhel-*-dvd.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isouuid --fs-uuid (loop)
     linux (loop)/isolinux/vmlinuz root=live:UUID=${isouuid} iso-scan/filename=${isofile} inst.repo=file:///run/initramfs/live ${rhelopts} rescue
     initrd (loop)/isolinux/initrd.img
@@ -42,7 +42,7 @@ for isofile in $isopath/rhel/rhel-*-dvd.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isouuid --fs-uuid (loop)
     linux (loop)/isolinux/vmlinuz root=live:UUID=${isouuid} iso-scan/filename=${isofile} inst.repo=file:///run/initramfs/live ${rhelopts} inst.ks=hd:UUID=${rootuuid}:${ksfile}
     initrd (loop)/isolinux/initrd.img

--- a/grub2/inc-rockylinux.cfg
+++ b/grub2/inc-rockylinux.cfg
@@ -13,7 +13,7 @@ for isofile in $isopath/rockylinux/Rocky-Workstation-*.iso; do
     set isoname=$3
     set version=$4
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     if [ "${grub_platform}" = "efi" ]; then
       linuxefi (loop)/isolinux/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image rhgb rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}

--- a/grub2/inc-supergrub2disk.cfg
+++ b/grub2/inc-supergrub2disk.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/super_grub2_disk_*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     unset theme
     set root=(loop)
     set iso_path=$isofile

--- a/grub2/inc-systemrescue.cfg
+++ b/grub2/inc-systemrescue.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/systemrescue/systemrescue-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/sysresccd/boot/*/vmlinuz archisobasedir=sysresccd img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile} copytoram
     initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/*/sysresccd.img
@@ -19,7 +19,7 @@ for isofile in $isopath/systemrescue/systemrescue-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/sysresccd/boot/*/vmlinuz archisobasedir=sysresccd img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
     initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/*/sysresccd.img

--- a/grub2/inc-tails.cfg
+++ b/grub2/inc-tails.cfg
@@ -10,7 +10,7 @@ for isofile in $isopath/tails/tails-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} config apparmor=1 security=apparmor nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails kaslr slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 quiet
     initrd (loop)/live/initrd.img
   }

--- a/grub2/inc-ubuntu.cfg
+++ b/grub2/inc-ubuntu.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/ubuntu/ubuntu-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }

--- a/grub2/inc-void.cfg
+++ b/grub2/inc-void.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/void/void-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/boot/vmlinuz iso-scan/filename=${isofile} root=live:CDLABEL=${isolabel} ro init=/sbin/init rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap vconsole.unicode=1 vconsole.keymap=us locale.LANG=en_US.UTF-8
     initrd (loop)/boot/initrd
@@ -20,7 +20,7 @@ for isofile in $isopath/void/void-live-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     probe --set isolabel --label (loop)
     linux (loop)/boot/vmlinuz iso-scan/filename=${isofile} root=live:CDLABEL=${isolabel} ro init=/sbin/init rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap vconsole.unicode=1 vconsole.keymap=us locale.LANG=en_US.UTF-8 rd.live.ram
     initrd (loop)/boot/initrd

--- a/grub2/inc-xubuntu.cfg
+++ b/grub2/inc-xubuntu.cfg
@@ -11,7 +11,7 @@ for isofile in $isopath/xubuntu/xubuntu-*.iso; do
     set isofile=$2
     set isoname=$3
     echo "Using ${isoname}..."
-    loopback loop $isofile
+    loop $isofile
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }


### PR DESCRIPTION
If grub can't start some iso, we're left with (loop) tied to that iso no matter what other item in grub menu we try to start.

Sample case (extreme one): try booting Ubuntu 10.04.4 iso. Grub will report error 'kernel too old ...' Now try any other item in grub menu and notice grub error 'device name already exists ...'

Sample case (more generic): try booting Ubuntu 14.04.6 iso. Grub will report error 'file casper/vmlinuz not found ...' Now try any other item in grub menu and notice grub error 'device name already exists ...'

The user has two options to reset the wicked state: either reboot or issue 'loopback -d loop' in grub console. It would be much more user friendly to make the problem never emerge.

---

The commit is literally the `loop` function definition and `loopback loop` replaced with `loop` everywhere in `grub2/inc-*.cfg`