### PR TITLE
Sorted menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,38 @@ disabled, so to skip any distribution, just don't copy any files into it.
 Download the right ISO image(s) to the matching directory. If you require
 boot parameter tweaks, edit the appropriate `boot/grub2/inc-*.cfg` file.
 
+Items order in the menu
+------------
+
+Menu items for a distro are ordered by modification time of the iso files
+starting from the most recent ones. If some iso files have the same mtime, their
+menu items are ordered alphabetically.
+
+Here is a generic idea how to keep it nicely ordered when you have multiple
+releases of some distro:
+
+- touch your **release** iso files with the release date
+- touch your **point release** iso files with the original release date plus a
+  day per point. This is a way to ensure point releases never pop above the next
+  release like Debian 10.13.0 (released 10 Sep 2022) would still be below Debian
+  11.0.0 (released 14 August 2021)
+- in case there are multiple flavours of some iso but the version is the same,
+  touch all of them with the same date for the whole group to be ordered
+  alphabetically
+
+Sample ordered menu:
+
+|                                    | iso mtime               |
+|------------------------------------|-------------------------|
+| Debian Live 12.0.0 amd64 standard  | 10 June 2023            |
+| Debian Live 11.7.0 amd64 gnome     | 14 August 2021 + 7 days |
+| Debian Live 11.7.0 amd64 kde       | 14 August 2021 + 7 days |
+| Debian Live 11.7.0 amd64 standard  | 14 August 2021 + 7 days |
+| Debian Live 11.0.0 amd64 gnome     | 14 August 2021          |
+| Debian Live 11.0.0 amd64 kde       | 14 August 2021          |
+| Debian Live 11.0.0 amd64 standard  | 14 August 2021          |
+| Debian Live 10.13.0 amd64 standard | 6 July 2019 + 13 days   |
+| Debian Live 9.13.0 amd64 standard  | 17 June 2017 + 13 days  |
 
 Special Cases
 -------------

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -29,6 +29,70 @@ function loop {
   loopback loop "$1"
 }
 
+# Order by mtime DESC, literal value ASC
+function cmp_mtime_literal {
+    if [ "$1" -nt "$2" ]; then
+        true
+    elif [ "$1" -ot "$2" ]; then
+        false
+    else
+        [ "$1" '<' "$2" ]
+    fi
+}
+
+# Feed a list of isos (by one) to a callback in a sorted manner. The order is
+# set by cmp_mtime_literal function. Args: callback iso1 iso2 ..
+function for_each_sorted {
+    # We expect the list of isos to come from a pattern expansion. In case the
+    # pattern did not expand to anything existing, do nothing.
+    if [ ! -e "$2" ]; then return; fi
+
+    set my_callback="$1"
+    shift
+
+    # Below we loop over the set of iso files, pick the "best" one (in terms of
+    # cmp_mtime_literal) in the current set and exclude it from the set before
+    # starting the next iteration. When the "best" iso in the current set is
+    # found, we feed it to the callback.
+
+    # In a generic shell "$@" expands to nothing when there are no args. In
+    # grubscript it expands to an empty arg. Because of that the loop below can
+    # only reduce the list down to two elements. With just two elements left it
+    # would run infinitely if allowed.
+
+    while [ $# -gt 2 ]; do
+        set my_best="$1"
+        shift
+
+        for _ in "$@"; do
+            set my_next="$1"
+            shift
+
+            if cmp_mtime_literal "$my_next" "$my_best"; then
+                # next is better
+                setparams "$@" "$my_best"
+                set my_best="$my_next"
+            else
+                # next is nothing special
+                setparams "$@" "$my_next"
+            fi
+        done
+
+        "$my_callback" "$my_best"
+    done
+
+    if [ $# -eq 2 ]; then
+      if cmp_mtime_literal "$2" "$1"; then
+         setparams "$2" "$1"
+      fi
+
+      "$my_callback" "$1"
+      shift
+    fi
+
+    "$my_callback" "$1"
+}
+
 # Menu!
 # We (ab)use 'for' to check for at least one ISO file to show the menu entry
 

--- a/grub2/inc-almalinux.cfg
+++ b/grub2/inc-almalinux.cfg
@@ -2,8 +2,9 @@
 #   AlmaLinux-9.1-x86_64-Live-GNOME-Mini.iso
 #   AlmaLinux-9.1-update-1-x86_64-Live-XFCE.iso
 #   AlmaLinux-9-latest-x86_64-Live-KDE.iso
-for isofile in $isopath/almalinux/AlmaLinux-*-Live-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -26,4 +27,6 @@ for isofile in $isopath/almalinux/AlmaLinux-*-Live-*.iso; do
     linux${efi} (loop)/isolinux/vmlinuz0 root=live:CDLABEL=${isolabel} rd.live.image rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}
     initrd${efi} (loop)/isolinux/initrd0.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/almalinux/AlmaLinux-*-Live-*.iso

--- a/grub2/inc-antix.cfg
+++ b/grub2/inc-antix.cfg
@@ -1,6 +1,7 @@
 # antiX
-for isofile in $isopath/antix/antiX-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,4 +16,6 @@ for isofile in $isopath/antix/antiX-*.iso; do
     linux (loop)/antiX/vmlinuz fromiso=${isofile} from=all buuid=${rootuuid} quiet splash=v disable=lx
     initrd (loop)/antiX/initrd.gz
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/antix/antiX-*.iso

--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -1,6 +1,7 @@
 # Arch
-for isofile in $isopath/arch/archlinux-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -14,4 +15,6 @@ for isofile in $isopath/arch/archlinux-*.iso; do
     linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop="${isofile}" earlymodules=loop
     initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/initramfs-linux.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/arch/archlinux-*.iso

--- a/grub2/inc-artix.cfg
+++ b/grub2/inc-artix.cfg
@@ -1,6 +1,7 @@
 # Artix
-for isofile in $isopath/artix/artix-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:devariant \
@@ -27,4 +28,6 @@ for isofile in $isopath/artix/artix-*.iso; do
       initrd (loop)/boot/intel-ucode.img (loop)/boot/amd-ucode.img (loop)/boot/initramfs-x86_64.img
     }
   fi
-done
+}
+
+for_each_sorted add_menu "$isopath"/artix/artix-*.iso

--- a/grub2/inc-bodhi.cfg
+++ b/grub2/inc-bodhi.cfg
@@ -1,7 +1,8 @@
 # Bodhi Linux
 # NOTE: As of 5.0.0 the "legacy" image can't mount FAT32 (charset error)
-for isofile in $isopath/bodhi/bodhi-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,4 +16,6 @@ for isofile in $isopath/bodhi/bodhi-*.iso; do
     linux (loop)/casper/vmlinuz iso-scan/filename=${isofile} file=/cdrom/preseed/custom.seed boot=casper quiet splash
     initrd (loop)/casper/initrd*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/bodhi/bodhi-*.iso

--- a/grub2/inc-centos.cfg
+++ b/grub2/inc-centos.cfg
@@ -1,10 +1,7 @@
 # CentOS
-for isofile in $isopath/centos/CentOS-*-Live*.iso; do
-  if [ ! -e "$isofile" ]; then
-    echo "Directory empty..."
-    sleep 2
-    break
-  fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -21,4 +18,6 @@ for isofile in $isopath/centos/CentOS-*-Live*.iso; do
     linux (loop)/isolinux/vmlinuz0 root=live:CDLABEL=${isolabel} rootfstype=auto ro rd.live.image quiet rhgb rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}
     initrd (loop)/isolinux/initrd0.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/centos/CentOS-*-Live*.iso

--- a/grub2/inc-clonezilla.cfg
+++ b/grub2/inc-clonezilla.cfg
@@ -1,6 +1,7 @@
 # Clonezilla
-for isofile in $isopath/clonezilla/clonezilla-live-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -14,4 +15,6 @@ for isofile in $isopath/clonezilla/clonezilla-live-*.iso; do
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} union=overlay components quiet toram=live,syslinux
     initrd (loop)/live/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/clonezilla/clonezilla-live-*.iso

--- a/grub2/inc-debian.cfg
+++ b/grub2/inc-debian.cfg
@@ -1,6 +1,7 @@
 # Debian GNU/Linux
-for isofile in $isopath/debian/debian-live-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,7 +16,10 @@ for isofile in $isopath/debian/debian-live-*.iso; do
     linux (loop)/live/vmlinuz-* boot=live findiso=${isofile} components noeject
     initrd (loop)/live/initrd.img-*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/debian/debian-live-*.iso
+
 # Special mini.iso installer - Lots of options, so chain its own grub.cfg
 if [ -e "$isopath/debian/mini.iso" ]; then
   menuentry "Debian mini.iso" --class debian {

--- a/grub2/inc-elementary.cfg
+++ b/grub2/inc-elementary.cfg
@@ -1,6 +1,7 @@
 # Elementary OS
-for isofile in $isopath/elementary/elementaryos-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -14,4 +15,6 @@ for isofile in $isopath/elementary/elementaryos-*.iso; do
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} quiet splash
     initrd (loop)/casper/initrd.lz
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/elementary/elementaryos-*.iso

--- a/grub2/inc-fedora.cfg
+++ b/grub2/inc-fedora.cfg
@@ -1,6 +1,7 @@
 # Fedora
-for isofile in $isopath/fedora/Fedora-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -16,4 +17,6 @@ for isofile in $isopath/fedora/Fedora-*.iso; do
     linux (loop)/images/pxeboot/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
     initrd (loop)/images/pxeboot/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/fedora/Fedora-*.iso

--- a/grub2/inc-gentoo.cfg
+++ b/grub2/inc-gentoo.cfg
@@ -1,6 +1,7 @@
 # Gentoo
-for isofile in $isopath/gentoo/*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:kind \
@@ -16,4 +17,6 @@ for isofile in $isopath/gentoo/*.iso; do
     linux (loop)/boot/gentoo isoboot=${isofile} nodhcp looptype=squashfs loop=/image.squashfs cdroot docache dokeymap
     initrd (loop)/boot/gentoo.igz
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/gentoo/*.iso

--- a/grub2/inc-gparted.cfg
+++ b/grub2/inc-gparted.cfg
@@ -1,6 +1,7 @@
 # GParted
-for isofile in $isopath/gparted/gparted-live-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -22,4 +23,6 @@ for isofile in $isopath/gparted/gparted-live-*.iso; do
     linux (loop)/live/vmlinuz boot=live username=user quiet findiso=${isofile} toram=filesystem.squashfs
     initrd (loop)/live/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/gparted/gparted-live-*.iso

--- a/grub2/inc-grml.cfg
+++ b/grub2/inc-grml.cfg
@@ -1,6 +1,7 @@
 # Grml
-for isofile in $isopath/grml/grml*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:arch \
@@ -17,4 +18,6 @@ for isofile in $isopath/grml/grml*.iso; do
     export iso_path
     configfile /boot/grub/loopback.cfg
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/grml/grml*.iso

--- a/grub2/inc-ipxe.cfg
+++ b/grub2/inc-ipxe.cfg
@@ -1,33 +1,39 @@
 # iPXE .iso "DOS magic is invalid." on EFI, so use special .efi
+function add_menu_bios {
+  isofile="$1"
+
+  regexp \
+    --set 1:isoname \
+    --set 2:version \
+    "^${isopath}/ipxe/(ipxe(.*)?\.iso)\$" "${isofile}"
+  menuentry "iPXE (iso) ${version}" "${isofile}" "${isoname}" --class net {
+    set isofile=$2
+    set isoname=$3
+    echo "Using ${isoname}..."
+    loop $isofile
+    linux (loop)/ipxe.lkrn
+  }
+}
+
+function add_menu_efi {
+  efifile="$1"
+
+  regexp \
+    --set 1:efiname \
+    --set 2:version \
+    "^${isopath}/ipxe/(ipxe(.*)?\.efi)\$" "${efifile}"
+  menuentry "iPXE (efi) ${version}" "${efifile}" "${efiname}" --class net {
+    set efifile=$2
+    set efiname=$3
+    echo "Using ${efiname}..."
+    insmod part_gpt
+    insmod chain
+    chainloader ${efifile}
+  }
+}
+
 if [ "${grub_platform}" != "efi" ]; then
-  for isofile in $isopath/ipxe/ipxe*.iso; do
-    if [ ! -e "$isofile" ]; then break; fi
-    regexp \
-      --set 1:isoname \
-      --set 2:version \
-      "^${isopath}/ipxe/(ipxe(.*)?\.iso)\$" "${isofile}"
-    menuentry "iPXE (iso) ${version}" "${isofile}" "${isoname}" --class net {
-      set isofile=$2
-      set isoname=$3
-      echo "Using ${isoname}..."
-      loop $isofile
-      linux (loop)/ipxe.lkrn
-    }
-  done
+  for_each_sorted add_menu_bios "$isopath"/ipxe/ipxe*.iso
 else
-  for efifile in $isopath/ipxe/ipxe*.efi; do
-    if [ ! -e "$efifile" ]; then break; fi
-    regexp \
-      --set 1:efiname \
-      --set 2:version \
-      "^${isopath}/ipxe/(ipxe(.*)?\.efi)\$" "${efifile}"
-    menuentry "iPXE (efi) ${version}" "${efifile}" "${efiname}" --class net {
-      set efifile=$2
-      set efiname=$3
-      echo "Using ${efiname}..."
-      insmod part_gpt
-      insmod chain
-      chainloader ${efifile}
-    }
-  done
+  for_each_sorted add_menu_efi "$isopath"/ipxe/ipxe*.efi
 fi

--- a/grub2/inc-kali.cfg
+++ b/grub2/inc-kali.cfg
@@ -1,6 +1,7 @@
 # Kali
-for isofile in $isopath/kali/kali-linux-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -22,4 +23,6 @@ for isofile in $isopath/kali/kali-linux-*.iso; do
     linux (loop)/live/vmlinuz-*-amd64 findiso=${isofile} boot=live components splash username=root hostname=kali noswap noautomount
     initrd (loop)/live/initrd.img-*-amd64
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/kali/kali-linux-*.iso

--- a/grub2/inc-kubuntu.cfg
+++ b/grub2/inc-kubuntu.cfg
@@ -1,6 +1,7 @@
 # Kubuntu
-for isofile in $isopath/kubuntu/kubuntu-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,4 +16,6 @@ for isofile in $isopath/kubuntu/kubuntu-*.iso; do
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/kubuntu/kubuntu-*.iso

--- a/grub2/inc-linuxmint.cfg
+++ b/grub2/inc-linuxmint.cfg
@@ -1,6 +1,7 @@
 # Mint
-for isofile in $isopath/linuxmint/linuxmint-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu_mint {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,10 +16,12 @@ for isofile in $isopath/linuxmint/linuxmint-*.iso; do
     linux (loop)/casper/vmlinuz file=/cdrom/preseed/linuxmint.seed boot=casper iso-scan/filename=${isofile} quiet splash --
     initrd (loop)/casper/initrd.lz
   }
-done
+}
+
 # Debian Edition
-for isofile in $isopath/linuxmint/lmde-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu_lmde {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -33,4 +36,7 @@ for isofile in $isopath/linuxmint/lmde-*.iso; do
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} live-config live-media-path=/live quiet splash --
     initrd (loop)/live/initrd.lz
   }
-done
+}
+
+for_each_sorted add_menu_mint "$isopath"/linuxmint/linuxmint-*.iso
+for_each_sorted add_menu_lmde "$isopath"/linuxmint/lmde-*.iso

--- a/grub2/inc-manjaro.cfg
+++ b/grub2/inc-manjaro.cfg
@@ -1,6 +1,7 @@
 # Manjaro
-for isofile in $isopath/manjaro/manjaro-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -16,4 +17,6 @@ for isofile in $isopath/manjaro/manjaro-*.iso; do
     linux (loop)/boot/vmlinuz-x86_64 img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
     initrd (loop)/boot/intel_ucode.img (loop)/boot/amd_ucode.img (loop)/boot/initramfs-x86_64.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/manjaro/manjaro-*.iso

--- a/grub2/inc-memtest.cfg
+++ b/grub2/inc-memtest.cfg
@@ -1,32 +1,38 @@
 # Memtest86+
+function add_menu_bios {
+  binfile="$1"
+
+  regexp \
+    --set 1:binname \
+    --set 2:version \
+    "^${isopath}/memtest/(memtest(.*)?\.bin)\$" "${binfile}"
+  menuentry "Memtest (bin) ${version}" "${binfile}" "${binname}" --class memtest {
+    set binfile=$2
+    set binname=$3
+    echo "Using ${binname}..."
+    linux ${binfile}
+  }
+}
+
+function add_menu_efi {
+  efifile="$1"
+
+  regexp \
+    --set 1:efiname \
+    --set 2:version \
+    "^${isopath}/memtest/(memtest(.*)?\.efi)\$" "${efifile}"
+  menuentry "Memtest (efi) ${version}" "${efifile}" "${efiname}" --class memtest {
+    set efifile=$2
+    set efiname=$3
+    echo "Using ${efiname}..."
+    insmod part_gpt
+    insmod chain
+    chainloader ${efifile}
+  }
+}
+
 if [ "${grub_platform}" != "efi" ]; then
-  for binfile in $isopath/memtest/memtest*.bin; do
-    if [ ! -e "$binfile" ]; then break; fi
-    regexp \
-      --set 1:binname \
-      --set 2:version \
-      "^${isopath}/memtest/(memtest(.*)?\.bin)\$" "${binfile}"
-    menuentry "Memtest (bin) ${version}" "${binfile}" "${binname}" --class memtest {
-      set binfile=$2
-      set binname=$3
-      echo "Using ${binname}..."
-      linux ${binfile}
-    }
-  done
+  for_each_sorted add_menu_bios "$isopath"/memtest/memtest*.bin
 else
-  for efifile in $isopath/memtest/memtest*.efi; do
-    if [ ! -e "$efifile" ]; then break; fi
-    regexp \
-      --set 1:efiname \
-      --set 2:version \
-      "^${isopath}/memtest/(memtest(.*)?\.efi)\$" "${efifile}"
-    menuentry "Memtest (efi) ${version}" "${efifile}" "${efiname}" --class memtest {
-      set efifile=$2
-      set efiname=$3
-      echo "Using ${efiname}..."
-      insmod part_gpt
-      insmod chain
-      chainloader ${efifile}
-    }
-  done
+  for_each_sorted add_menu_efi "$isopath"/memtest/memtest*.efi
 fi

--- a/grub2/inc-netrunner.cfg
+++ b/grub2/inc-netrunner.cfg
@@ -1,6 +1,7 @@
 # Netrunner
-for isofile in $isopath/netrunner/netrunner-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 3:variant \
@@ -26,4 +27,6 @@ for isofile in $isopath/netrunner/netrunner-*.iso; do
       initrd (loop)/boot/intel_ucode.img (loop)/boot/initramfs-x86_64.img
     }
   fi
-done
+}
+
+for_each_sorted add_menu "$isopath"/netrunner/netrunner-*.iso

--- a/grub2/inc-openbsd.cfg
+++ b/grub2/inc-openbsd.cfg
@@ -8,8 +8,9 @@
 # as such. Otherwise "amd64" is used as default. Examples: cd66-macppc.iso,
 # install66-i386.iso
 
-for isofile in $isopath/openbsd/*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -32,4 +33,6 @@ for isofile in $isopath/openbsd/*.iso; do
     set root=(loop)
     kopenbsd /${version}/${arch}/bsd.rd
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/openbsd/*.iso

--- a/grub2/inc-peppermint.cfg
+++ b/grub2/inc-peppermint.cfg
@@ -1,6 +1,7 @@
 # Peppermint
-for isofile in $isopath/peppermint/Peppermint-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -14,4 +15,6 @@ for isofile in $isopath/peppermint/Peppermint-*.iso; do
     linux (loop)/casper/vmlinuz* file=(loop)/preseed/peppermint.seed boot=casper iso-scan/filename=${isofile} quiet splash
     initrd (loop)/casper/initrd*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/peppermint/Peppermint-*.iso

--- a/grub2/inc-porteus.cfg
+++ b/grub2/inc-porteus.cfg
@@ -1,7 +1,8 @@
 # Porteus
 # NOTE: Doesn't support VirtIO, set block device to SATA or IDE when testing
-for isofile in $isopath/porteus/Porteus-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -16,4 +17,6 @@ for isofile in $isopath/porteus/Porteus-*.iso; do
     linux (loop)/boot/syslinux/vmlinuz from=${isofile}
     initrd (loop)/boot/syslinux/initrd.xz
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/porteus/Porteus-*.iso

--- a/grub2/inc-rhel.cfg
+++ b/grub2/inc-rhel.cfg
@@ -12,8 +12,9 @@ set ksfile="${isopath}/rhel/ks.cfg"
 # inst.ks=http://server.mydomain.com/directory/ks.cfg inst.ks.sendmac
 set rhelopts="quiet"
 
-for isofile in $isopath/rhel/rhel-*-dvd.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -47,4 +48,6 @@ for isofile in $isopath/rhel/rhel-*-dvd.iso; do
     linux (loop)/isolinux/vmlinuz root=live:UUID=${isouuid} iso-scan/filename=${isofile} inst.repo=file:///run/initramfs/live ${rhelopts} inst.ks=hd:UUID=${rootuuid}:${ksfile}
     initrd (loop)/isolinux/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/rhel/rhel-*-dvd.iso

--- a/grub2/inc-rockylinux.cfg
+++ b/grub2/inc-rockylinux.cfg
@@ -2,8 +2,9 @@
 #   Rocky-9-Cinnamon-aarch64-latest.iso
 #   Rocky-9.2-Workstation-Lite-aarch64-20230513.0.iso
 #   Rocky-9.2-XFCE-x86_64-20230513.0.iso
-for isofile in $isopath/rockylinux/Rocky-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -27,4 +28,6 @@ for isofile in $isopath/rockylinux/Rocky-*.iso; do
     linux${efi} (loop)/images/pxeboot/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image rhgb rd.luks=0 rd.md=0 rd.dm=0 iso-scan/filename=${isofile}
     initrd${efi} (loop)/images/pxeboot/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/rockylinux/Rocky-*.iso

--- a/grub2/inc-supergrub2disk.cfg
+++ b/grub2/inc-supergrub2disk.cfg
@@ -1,6 +1,7 @@
 # Super Grub2 Disk
-for isofile in $isopath/super_grub2_disk_*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:variant \
@@ -17,4 +18,6 @@ for isofile in $isopath/super_grub2_disk_*.iso; do
     export iso_path
     configfile /boot/grub/loopback.cfg
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/super_grub2_disk_*.iso

--- a/grub2/inc-systemrescue.cfg
+++ b/grub2/inc-systemrescue.cfg
@@ -1,6 +1,7 @@
 # SystemRescue (6+ - Arch)
-for isofile in $isopath/systemrescue/systemrescue-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -24,4 +25,6 @@ for isofile in $isopath/systemrescue/systemrescue-*.iso; do
     linux (loop)/sysresccd/boot/*/vmlinuz archisobasedir=sysresccd img_dev=/dev/disk/by-uuid/${rootuuid} img_loop=${isofile}
     initrd (loop)/sysresccd/boot/intel_ucode.img (loop)/sysresccd/boot/amd_ucode.img (loop)/sysresccd/boot/*/sysresccd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/systemrescue/systemrescue-*.iso

--- a/grub2/inc-tails.cfg
+++ b/grub2/inc-tails.cfg
@@ -1,6 +1,7 @@
 # Tails
-for isofile in $isopath/tails/tails-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:arch \
@@ -14,4 +15,6 @@ for isofile in $isopath/tails/tails-*.iso; do
     linux (loop)/live/vmlinuz boot=live findiso=${isofile} config apparmor=1 security=apparmor nopersistence noprompt timezone=Etc/UTC block.events_dfl_poll_msecs=1000 splash noautologin module=Tails kaslr slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 quiet
     initrd (loop)/live/initrd.img
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/tails/tails-*.iso

--- a/grub2/inc-ubuntu.cfg
+++ b/grub2/inc-ubuntu.cfg
@@ -1,6 +1,7 @@
 # Ubuntu
-for isofile in $isopath/ubuntu/ubuntu-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,4 +16,6 @@ for isofile in $isopath/ubuntu/ubuntu-*.iso; do
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/ubuntu/ubuntu-*.iso

--- a/grub2/inc-void.cfg
+++ b/grub2/inc-void.cfg
@@ -1,6 +1,7 @@
 # Void
-for isofile in $isopath/void/void-live-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:arch \
@@ -25,4 +26,6 @@ for isofile in $isopath/void/void-live-*.iso; do
     linux (loop)/boot/vmlinuz iso-scan/filename=${isofile} root=live:CDLABEL=${isolabel} ro init=/sbin/init rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap vconsole.unicode=1 vconsole.keymap=us locale.LANG=en_US.UTF-8 rd.live.ram
     initrd (loop)/boot/initrd
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/void/void-live-*.iso

--- a/grub2/inc-xubuntu.cfg
+++ b/grub2/inc-xubuntu.cfg
@@ -1,6 +1,7 @@
 # Xubuntu
-for isofile in $isopath/xubuntu/xubuntu-*.iso; do
-  if [ ! -e "$isofile" ]; then break; fi
+function add_menu {
+  isofile="$1"
+
   regexp \
     --set 1:isoname \
     --set 2:version \
@@ -15,4 +16,6 @@ for isofile in $isopath/xubuntu/xubuntu-*.iso; do
     linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=${isofile} fsck.mode=skip quiet splash
     initrd (loop)/casper/initrd*
   }
-done
+}
+
+for_each_sorted add_menu "$isopath"/xubuntu/xubuntu-*.iso


### PR DESCRIPTION
Currently GLIM propagates menu items in the order or some wildcard expansion like `debian/debian-live-*.iso`. It is not what most users would like. Here I introduce sorting by iso mtime DESC first, iso filename literal value ASC next.

Main commit message:

```
Support functions for sorted menu feature

In generic shells the wildcard expansion produces an alphabetically ASC
sorted list. In grubscript there is no sorting, the items are generated in
so called "directory order" ('ls -U'), as they appear in the fs. Here we
introduce sorting based on file mtime DESC first, literal filename ASC
next.

In a typical scenario when a user puts a newly released iso into some dir
the new iso would naturally pop to the top in the dir's menu. In case there
is some iso in multiple flavours for the same version, a user should touch
those with the same mtime for the group to be sorted alphabetically.

When storing isos not sequentially it is a good idea to touch them with
their release date or mtime of some file from inside the iso like the
kernel or initrd.

Points of interest in grub sources:
- grub-core/commands/wildcard.c: wildcard_expand -> match_files -> fs->fs_dir
- grub-core/fs/fat.c: grub_fat_dir -> grub_fat_iterate_dir_next
```

Two other commits modify the `inc-*.cfg` files to use the feature. The changes are trivial. The big commit can be reviewed as-is. For the smaller one use 'ignore leading whitespace' setting in your client to grasp the actual changes quick.

Before:

```
Ubuntu 20.04.5 amd64 desktop
Ubuntu 22.04.2 amd64 desktop
Ubuntu 16.04.7 amd64 desktop
Ubuntu 18.04.6 amd64 desktop
```

After:

```
Ubuntu 22.04.2 amd64 desktop
Ubuntu 20.04.5 amd64 desktop
Ubuntu 18.04.6 amd64 desktop
Ubuntu 16.04.7 amd64 desktop
```
