### PR TITLE
Limit the scope of README parsing in glim.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Once finished, you may change the filesystem label to anything you like.
 
 The supported `boot/iso/` sub-directories (in alphabetical order) are :
 
+[//]: # (distro-list-start)
+
     almalinux
     antix
     arch
@@ -79,6 +81,8 @@ The supported `boot/iso/` sub-directories (in alphabetical order) are :
     ubuntu
     void
     xubuntu
+
+[//]: # (distro-list-end)
 
 Any unpopulated directory will have the matching boot menu entry automatically
 disabled, so to skip any distribution, just don't copy any files into it.

--- a/glim.sh
+++ b/glim.sh
@@ -161,7 +161,12 @@ fi
 echo "GLIM installed! Time to populate the boot/iso/ sub-directories."
 
 # Now also pre-create all supported sub-directories since empty are ignored
-for DIR in $(sed -E -n 's/^    ([a-z]+)$/\1/p' `dirname $0`/README.md); do
+args=(
+  -E -n
+  '/\(distro-list-start\)/,/\(distro-list-end\)/{s,^\s+([a-z]+)$,\1,p}'
+)
+
+for DIR in $(sed "${args[@]}" "$(dirname "$0")"/README.md); do
   [[ -d ${USBMNT}/boot/iso/${DIR} ]] || ${CMD_PREFIX} mkdir ${USBMNT}/boot/iso/${DIR}
 done
 


### PR DESCRIPTION
glim.sh does parse the list to precreate the distro subdirs. With the markers we limit the scope of parsing to the bare minimum.

References:
https://stackoverflow.com/questions/4823468/comments-in-markdown

----

The `$args` thing there is to make lines shorter. Loooong command inside `$(..)` looks not healthy