### PR TITLE
Small fix for Debian mini.iso

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -159,7 +159,7 @@ for isofile in ${isopath}/clonezilla/clonezilla-live-*.iso; do
   fi
 done
 
-for isofile in ${isopath}/debian/debian-live-*.iso; do
+for isofile in ${isopath}/debian/debian-live-*.iso ${isopath}/debian/mini.iso; do
   if [ -e "$isofile" ]; then
     menuentry "Debian >" --class debian {
       configfile "${prefix}/inc-debian.cfg"


### PR DESCRIPTION
Currently Debian is not listed in the menu if `mini.iso` is the only one there