### PR TITLE
Fix indent in grub.cfg

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -31,66 +31,66 @@ function loop {
 
 # Order by mtime DESC, literal value ASC
 function cmp_mtime_literal {
-    if [ "$1" -nt "$2" ]; then
-        true
-    elif [ "$1" -ot "$2" ]; then
-        false
-    else
-        [ "$1" '<' "$2" ]
-    fi
+  if [ "$1" -nt "$2" ]; then
+    true
+  elif [ "$1" -ot "$2" ]; then
+    false
+  else
+    [ "$1" '<' "$2" ]
+  fi
 }
 
 # Feed a list of isos (by one) to a callback in a sorted manner. The order is
 # set by cmp_mtime_literal function. Args: callback iso1 iso2 ..
 function for_each_sorted {
-    # We expect the list of isos to come from a pattern expansion. In case the
-    # pattern did not expand to anything existing, do nothing.
-    if [ ! -e "$2" ]; then return; fi
+  # We expect the list of isos to come from a pattern expansion. In case the
+  # pattern did not expand to anything existing, do nothing.
+  if [ ! -e "$2" ]; then return; fi
 
-    set my_callback="$1"
+  set my_callback="$1"
+  shift
+
+  # Below we loop over the set of iso files, pick the "best" one (in terms of
+  # cmp_mtime_literal) in the current set and exclude it from the set before
+  # starting the next iteration. When the "best" iso in the current set is
+  # found, we feed it to the callback.
+
+  # In a generic shell "$@" expands to nothing when there are no args. In
+  # grubscript it expands to an empty arg. Because of that the loop below can
+  # only reduce the list down to two elements. With just two elements left it
+  # would run infinitely if allowed.
+
+  while [ $# -gt 2 ]; do
+    set my_best="$1"
     shift
 
-    # Below we loop over the set of iso files, pick the "best" one (in terms of
-    # cmp_mtime_literal) in the current set and exclude it from the set before
-    # starting the next iteration. When the "best" iso in the current set is
-    # found, we feed it to the callback.
+    for _ in "$@"; do
+      set my_next="$1"
+      shift
 
-    # In a generic shell "$@" expands to nothing when there are no args. In
-    # grubscript it expands to an empty arg. Because of that the loop below can
-    # only reduce the list down to two elements. With just two elements left it
-    # would run infinitely if allowed.
-
-    while [ $# -gt 2 ]; do
-        set my_best="$1"
-        shift
-
-        for _ in "$@"; do
-            set my_next="$1"
-            shift
-
-            if cmp_mtime_literal "$my_next" "$my_best"; then
-                # next is better
-                setparams "$@" "$my_best"
-                set my_best="$my_next"
-            else
-                # next is nothing special
-                setparams "$@" "$my_next"
-            fi
-        done
-
-        "$my_callback" "$my_best"
+      if cmp_mtime_literal "$my_next" "$my_best"; then
+        # next is better
+        setparams "$@" "$my_best"
+        set my_best="$my_next"
+      else
+        # next is nothing special
+        setparams "$@" "$my_next"
+      fi
     done
 
-    if [ $# -eq 2 ]; then
-      if cmp_mtime_literal "$2" "$1"; then
-         setparams "$2" "$1"
-      fi
+    "$my_callback" "$my_best"
+  done
 
-      "$my_callback" "$1"
-      shift
+  if [ $# -eq 2 ]; then
+    if cmp_mtime_literal "$2" "$1"; then
+     setparams "$2" "$1"
     fi
 
     "$my_callback" "$1"
+    shift
+  fi
+
+  "$my_callback" "$1"
 }
 
 # Menu!


### PR DESCRIPTION
Some recently added chunks of code use indent 4 instead of 2

Use 'ignore leading spaces' in your client to review