### PR TITLE
Protect $root when passing control with 'configfile'

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -27,6 +27,17 @@ function use {
   echo "Using $1 ..."
 }
 
+# Save the original value of $root and set it to $1
+function change_root {
+  root_saved="$root"
+  root="$1"
+}
+
+# Restore $root value saved by change_root
+function restore_root {
+  root="$root_saved"
+}
+
 # Like 'loopback loop A', but check if (loop) already exists
 function loop {
   if [ -e (loop) ]; then loopback -d loop; fi

--- a/grub2/inc-debian.cfg
+++ b/grub2/inc-debian.cfg
@@ -26,7 +26,8 @@ if [ -e "$isopath/debian/mini.iso" ]; then
     set isofile=$isopath/debian/mini.iso
     use mini.iso
     loop $isofile
-    set root=(loop)
+    change_root (loop)
     configfile /boot/grub/grub.cfg
+    restore_root
   }
 fi

--- a/grub2/inc-grml.cfg
+++ b/grub2/inc-grml.cfg
@@ -13,10 +13,11 @@ function add_menu {
     set isoname=$3
     use "${isoname}"
     loop $isofile
-    set root=(loop)
+    change_root (loop)
     set iso_path=$isofile
     export iso_path
     configfile /boot/grub/loopback.cfg
+    restore_root
   }
 }
 

--- a/grub2/inc-supergrub2disk.cfg
+++ b/grub2/inc-supergrub2disk.cfg
@@ -13,10 +13,11 @@ function add_menu {
     use "${isoname}"
     loop $isofile
     unset theme
-    set root=(loop)
+    change_root (loop)
     set iso_path=$isofile
     export iso_path
     configfile /boot/grub/loopback.cfg
+    restore_root
   }
 }
 


### PR DESCRIPTION
Some of inc-*.cfg files load foreign configs with 'configfile'. Activating such menu item and then pressing 'Esc' we would "browse" back to the "page" for that distro. If we set $root to the loop for 'configfile' but not restore it later, all menu items on the "page" become useless.

---

Demo case for the bug:
- have some `grml` iso on your glim stick
- enter the `grml` section
- start the iso
- press `Esc`
- try start the iso again to no avail
