### PR TITLE
Improve for_each_sorted

### DIFF
--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -1,4 +1,10 @@
 # GLIM USB GRUB2 Configuration
+
+# In a generic shell "$@" expands to nothing when there are no args. In
+# grubscript it expands to an empty arg. Hence SPECIAL CARE SHOULD BE TAKEN
+# WHERE IT MATTERS. In particular `for .. in "$@"` loops should be wrapped in
+# `if [ $# -gt 0 ] .. fi`
+
 insmod regexp
 
 # Required for GUI and to prevent "No video mode set" error
@@ -58,54 +64,63 @@ function cmp_mtime_literal {
 # Feed a list of isos (by one) to a callback in a sorted manner. The order is
 # set by cmp_mtime_literal function. Args: callback iso1 iso2 ..
 function for_each_sorted {
-  # We expect the list of isos to come from a pattern expansion. In case the
-  # pattern did not expand to anything existing, do nothing.
-  if [ ! -e "$2" ]; then return; fi
-
-  set my_callback="$1"
+  set callback="$1"
   shift
+
+  # The list of isos could contain unmatched patterns. Filter those out.
+  if [ $# -gt 0 ]; then
+    for _ in "$@"; do
+      set first="$1"
+      shift
+
+      if [ -e "$first" ]; then
+        if [ $# -gt 0 ]; then
+          setparams "$@" "$first"
+        else
+          setparams "$first"
+        fi
+      fi
+    done
+  fi
+
+  if [ $# -eq 0 ]; then return; fi
 
   # Below we loop over the set of iso files, pick the "best" one (in terms of
   # cmp_mtime_literal) in the current set and exclude it from the set before
   # starting the next iteration. When the "best" iso in the current set is
   # found, we feed it to the callback.
 
-  # In a generic shell "$@" expands to nothing when there are no args. In
-  # grubscript it expands to an empty arg. Because of that the loop below can
-  # only reduce the list down to two elements. With just two elements left it
-  # would run infinitely if allowed.
-
   while [ $# -gt 2 ]; do
-    set my_best="$1"
+    set best="$1"
     shift
 
     for _ in "$@"; do
-      set my_next="$1"
+      set next="$1"
       shift
 
-      if cmp_mtime_literal "$my_next" "$my_best"; then
+      if cmp_mtime_literal "$next" "$best"; then
         # next is better
-        setparams "$@" "$my_best"
-        set my_best="$my_next"
+        setparams "$@" "$best"
+        set best="$next"
       else
         # next is nothing special
-        setparams "$@" "$my_next"
+        setparams "$@" "$next"
       fi
     done
 
-    "$my_callback" "$my_best"
+    "$callback" "$best"
   done
 
   if [ $# -eq 2 ]; then
     if cmp_mtime_literal "$2" "$1"; then
-     setparams "$2" "$1"
+      setparams "$2" "$1"
     fi
 
-    "$my_callback" "$1"
+    "$callback" "$1"
     shift
   fi
 
-  "$my_callback" "$1"
+  "$callback" "$1"
 }
 
 # Check if any of its args is an existing path


### PR DESCRIPTION
- move the comment about the `"$@"` usage peculiarities to the file header. It is a common issue, not just limited to that single function
- filter out unmatched patterns, check all args
- remove overcautious "local" vars prefix
- fix indentation (one line)