### PR TITLE
Update config for Arch Linux

### DIFF
--- a/grub2/inc-arch.cfg
+++ b/grub2/inc-arch.cfg
@@ -13,7 +13,7 @@ function add_menu {
     use "${isoname}"
     loop $isofile
     linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=/dev/disk/by-uuid/${rootuuid} img_loop="${isofile}" earlymodules=loop
-    initrd (loop)/arch/boot/intel-ucode.img (loop)/arch/boot/amd-ucode.img (loop)/arch/boot/x86_64/initramfs-linux.img
+    initrd (loop)/arch/boot/x86_64/initramfs-linux.img
   }
 }
 


### PR DESCRIPTION
Arch Linux iso stopped using external microcode images, they are all included in the initramfs now.
See https://gitlab.archlinux.org/archlinux/archiso/-/commit/2facc4630cd3677e5c61705a25d5d5594fd0cc80