### PR TITLE
Add support for >4GB ISO by optionally supporting a second partition. Plus other small improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,8 @@ Installation
 Mount the GLIM partition (and the GLIMISO partition if present) on your USB 
 memory stick (or external hard drive).
 
-Then clone this git repository:
-
-    git clone git@github.com:thias/glim.git
-
-And just run the script (as a normal user) :
+Then clone the git repository (or use Code > Download ZIP before unzipping it), 
+and just run the script (as a normal user) :
 
     ./glim.sh
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 GRUB2 Live ISO Multiboot
 ========================
 
-https://github.com/thias/glim | http://glee.thias.es/GLIM
+This version: https://github.com/cshandley-uk/bash_glim
+Forked from:  https://github.com/thias/glim | http://glee.thias.es/GLIM
 
 
 Overview
@@ -47,6 +48,8 @@ although you can still use a single partition if you want.
 easier to find, and also is in the same location whether you use one or two 
 partitions.
 
+* Added the `format_empty_disk.sh` script.
+
 
 Requirements
 ------------
@@ -75,6 +78,18 @@ But basically create an unformatted 1MB partition at the end of the disk, then
 change it's partition type to "BIOS Boot" (which has the 
 GUID `21686148-6449-6E6F-744E-656564454649`).  You can do this with GNOME's 
 Disks utility, without resorting to the terminal!
+
+Alternatively you can try using `format_empty_disk.sh`, my experimental new 
+script which will ask you a few questions before before setting-up an empty 
+disk with GLIM's recommended two partition set-up (plus a BIOS Boot partition), 
+ready to use with `glim.sh` itself.  I've tried to make it safe, so for example 
+it shouldn't delete any partitions, only create new ones... And in the event of 
+any errors, the script should stop rather than risk doing anything wrong.  
+HOWEVER, it is still a very new script, which likely contains bugs, especially 
+on systems different to my own, so please let me know about any problems you 
+experience.  You use this script entirely at your own risk.  If it formats your 
+entire computer, then that is your problem.  So please make sure you have a 
+recent backup before using it.
 
 
 Installation

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ https://github.com/thias/glim | http://glee.thias.es/GLIM
 Overview
 --------
 
-GLIM is a set of grub configuration files to turn a simple VFAT formatted USB
-memory stick with many GNU/Linux distribution ISO images into a neat device
-from which many different Live environments can be used.
+GLIM is a set of grub configuration files to turn a simple VFAT or FAT32 
+formatted USB memory stick containing many GNU/Linux distribution ISO images 
+into a neat device from which many different Live environments can be used.
 
 Advantages over extracting files or using special Live USB creation tools :
 
@@ -22,12 +22,12 @@ Disadvantages :
  * There is no persistence overlay for distributions which normally support it
  * Setting up isn't as easy as a simple cat from the ISO image to a block device
 
-My experience has been that the safest filesystem to use is FAT32
-(surprisingly!), though it will mean that ISO images greater than 4GB won't be
-supported. Other filesystems supported by GRUB2 also work, such as ext3/ext4,
-NTFS and exFAT, but the boot of the distributions must also support it, which
-isn't the case for many with NTFS (Ubuntu does, Fedora doesn't) and exFAT
-(Ubuntu doesn't, Fedora does). So FAT32 stays the safe bet.
+As modern Linux ISOs often exceed the 4GB file size limit of FAT32, GLIM now 
+supports a second partition using other filesystems supported by GRUB2, such as 
+ext3/ext4, NTFS or exFAT - but the distribution must also support booting from 
+it, which isn't the case for many with NTFS (Ubuntu does, Fedora doesn't) and 
+exFAT (Ubuntu doesn't, Fedora does).  Ext4 is a safe bet for the second 
+partition.
 
 
 Screenshots
@@ -37,18 +37,64 @@ Screenshots
 ![Ubuntu Submenu](https://github.com/thias/glim/raw/master/screenshots/GLIM-3.0-shot2.png)
 
 
+Recent changes
+--------------
+
+* GLIM now easily supports ISO files >4GB through the use of a second partition,
+although you can still use a single partition if you want.
+
+* The ISO folder has been moved from `boot/iso/` to just `iso/`, so that it's 
+easier to find, and also is in the same location whether you use one or two 
+partitions.
+
+
+Requirements
+------------
+
+You need a USB memory stick (or external hard drive!) partitioned & formatted 
+one of the following ways:
+
+1. A single partition formatted as FAT32 with the filesystem label `GLIM`. 
+It doesn't matter if it uses MBR or GPT.
+
+or
+
+2. Two partitions.  The first partition must be formatted as FAT32 with the 
+filesystem label `GLIM`.  The second partition should be formatted as Ext4 with 
+the filesystem label `GLIMISO`.  It's best if the USB stick uses MBR, but if it 
+uses GPT (as GNOME's Disks utility does) then GRUB only supports installing for 
+EFI (not BIOS) - unless you add a third BIOS Boot partition.  GLIM needs the 
+BIOS Boot partition to come after the other two partitions.
+
+See the link below for details on how to create a BIOS Boot partition:
+
+https://wiki.archlinux.org/title/GRUB#GUID_Partition_Table_(GPT)_specific_instructions
+
+But basically create an unformatted 1MB partition at the end of the disk, then 
+change it's partition type to "BIOS Boot" (which has the 
+GUID `21686148-6449-6E6F-744E-656564454649`).  You can do this with GNOME's 
+Disks utility, without resorting to the terminal!
+
+
 Installation
 ------------
 
-Once you have your USB memory with a single partition formatted as FAT32 with
-the filesystem label 'GLIM', mount it, clone this git repository and just run
-(as a normal user) :
+Mount the GLIM partition (and the GLIMISO partition if present) on your USB 
+memory stick (or external hard drive).
+
+Then clone this git repository:
+
+    git clone git@github.com:thias/glim.git
+
+And just run the script (as a normal user) :
 
     ./glim.sh
 
-Once finished, you may change the filesystem label to anything you like.
+Once finished, you may change the filesystem label to anything you like. 
+The script will have created an `iso` folder, inside of which you will see an 
+empty folder for each supported Linux distro.
 
-The supported `boot/iso/` sub-directories (in alphabetical order) are :
+The supported `iso` sub-directories (in alphabetical order) are :
 
 [//]: # (distro-list-start)
 
@@ -97,13 +143,13 @@ The supported `boot/iso/` sub-directories (in alphabetical order) are :
 [//]: # (distro-list-end)
 
 Any unpopulated directory will have the matching boot menu entry automatically
-disabled, so to skip any distribution, just don't copy any files into it.
+hidden, so to skip any distribution, just don't copy any files into it.
 
 Download the right ISO image(s) to the matching directory. If you require
 boot parameter tweaks, edit the appropriate `boot/grub2/inc-*.cfg` file.
 
 Items order in the menu
-------------
+-----------------------
 
 Menu items for a distro are ordered by modification time of the iso files
 starting from the most recent ones. If some iso files have the same mtime, their
@@ -220,6 +266,8 @@ create a GitHub pull request which includes :
 
 ---
 Copyleft 2012-2023 Matthias Saou http://matthias.saou.eu/
+
+Copyleft 2025 Chris Handley https://github.com/cshandley-uk
 
 All configuration files included are public domain. Do what you want with them.
 The invader logo was made by me, so unless the exact shape is covered by

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ script which will ask you a few questions before before setting-up an empty
 disk with GLIM's recommended two partition set-up (plus a BIOS Boot partition), 
 ready to use with `glim.sh` itself.  I've tried to make it safe, so for example 
 it shouldn't delete any partitions, only create new ones... And in the event of 
-any errors, the script should stop rather than risk doing anything wrong.  
+any errors, the script should stop rather than risk doing anything wrong. 
 HOWEVER, it is still a very new script, which likely contains bugs, especially 
 on systems different to my own, so please let me know about any problems you 
 experience.  You use this script entirely at your own risk.  If it formats your 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ memory stick (or external hard drive).
 
 Then clone the git repository (or use Code > Download ZIP before unzipping it), 
 and just run the script (as a normal user) :
-
-    ./glim.sh
-
+```
+./glim.sh
+```
 Once finished, you may change the filesystem label to anything you like. 
 The script will have created an `iso` folder, inside of which you will see an 
 empty folder for each supported Linux distro.
@@ -261,11 +261,12 @@ create a GitHub pull request which includes :
    may work.
  * An updated supported directories list in this README file.
 
+Credits
+-------
 
----
-Copyleft 2012-2023 Matthias Saou http://matthias.saou.eu/
-
-Copyleft 2025 Chris Handley https://github.com/cshandley-uk
+* Copyleft 2012-2023 Matthias Saou http://matthias.saou.eu/
+* Copyleft 2025 Chris Handley https://github.com/cshandley-uk
+* Copyleft 2025 Eugene Sanivsky (eugenesan) https://github.com/eugenesan
 
 All configuration files included are public domain. Do what you want with them.
 The invader logo was made by me, so unless the exact shape is covered by

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ It doesn't matter if it uses MBR or GPT.
 
 or
 
-2. Two partitions.  The first partition must be formatted as FAT32 with the 
-filesystem label `GLIM`.  The second partition should be formatted as Ext4 with 
-the filesystem label `GLIMISO`.  It's best if the USB stick uses MBR, but if it 
-uses GPT (as GNOME's Disks utility does) then GRUB only supports installing for 
-EFI (not BIOS) - unless you add a third BIOS Boot partition.  GLIM needs the 
-BIOS Boot partition to come after the other two partitions.
+2. Two partitions.  The small first partition must be formatted as FAT32 with 
+the filesystem label `GLIM`, I suggest 100MB in size.  The second partition 
+should be formatted as Ext4 with the filesystem label `GLIMISO`.  It's best if 
+the USB stick uses MBR, but if it uses GPT (as GNOME's Disks utility does) then 
+GRUB only supports installing for EFI (not BIOS) - unless you add a third BIOS 
+Boot partition.  GLIM needs the BIOS Boot partition to come after the other two 
+partitions.
 
 See the link below for details on how to create a BIOS Boot partition:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ GRUB2 Live ISO Multiboot
 ========================
 
 This version: https://github.com/cshandley-uk/bash_glim
-Forked from:  https://github.com/thias/glim | http://glee.thias.es/GLIM
+
+Forked from:  https://github.com/thias/glim | https://glee.thias.es/GLIM
 
 
 Overview
@@ -29,7 +30,6 @@ ext3/ext4, NTFS or exFAT - but the distribution must also support booting from
 it, which isn't the case for many with NTFS (Ubuntu does, Fedora doesn't) and 
 exFAT (Ubuntu doesn't, Fedora does).  Ext4 is a safe bet for the second 
 partition.
-
 
 Screenshots
 -----------
@@ -58,19 +58,19 @@ You need a USB memory stick (or external hard drive!) partitioned & formatted
 one of the following ways:
 
 1. A single partition formatted as FAT32 with the filesystem label `GLIM`. 
-It doesn't matter if it uses MBR or GPT.
+You can use MBR or GPT as needed (but legacy BIOS may need MBR).
 
 or
 
 2. Two partitions.  The small first partition must be formatted as FAT32 with 
 the filesystem label `GLIM`, I suggest 100MB in size.  The second partition 
-should be formatted as Ext4 with the filesystem label `GLIMISO`.  It's best if 
-the USB stick uses MBR, but if it uses GPT (as GNOME's Disks utility does) then 
-GRUB only supports installing for EFI (not BIOS) - unless you add a third BIOS 
-Boot partition.  GLIM needs the BIOS Boot partition to come after the other two 
-partitions.
+should be formatted as Ext4 with the filesystem label `GLIMISO`.  
 
-See the link below for details on how to create a BIOS Boot partition:
+It's best if the USB stick uses MBR, but if it uses GPT (as GNOME's Disks 
+utility does) then GRUB only supports installing for EFI (not BIOS) - unless you 
+add a third BIOS Boot partition.  GLIM needs the BIOS Boot partition to come 
+after the other two partitions.  See the link below for details on how to create 
+a BIOS Boot partition:
 
 https://wiki.archlinux.org/title/GRUB#GUID_Partition_Table_(GPT)_specific_instructions
 
@@ -79,17 +79,17 @@ change it's partition type to "BIOS Boot" (which has the
 GUID `21686148-6449-6E6F-744E-656564454649`).  You can do this with GNOME's 
 Disks utility, without resorting to the terminal!
 
-Alternatively you can try using `format_empty_disk.sh`, my experimental new 
-script which will ask you a few questions before before setting-up an empty 
-disk with GLIM's recommended two partition set-up (plus a BIOS Boot partition), 
-ready to use with `glim.sh` itself.  I've tried to make it safe, so for example 
-it shouldn't delete any partitions, only create new ones... And in the event of 
-any errors, the script should stop rather than risk doing anything wrong. 
-HOWEVER, it is still a very new script, which likely contains bugs, especially 
-on systems different to my own, so please let me know about any problems you 
-experience.  You use this script entirely at your own risk.  If it formats your 
-entire computer, then that is your problem.  So please make sure you have a 
-recent backup before using it.
+Or if you find partitioning difficult, then you can try using my experimental 
+new script `format_empty_disk.sh`, which will ask you a few questions before 
+before setting-up an empty disk with GLIM's recommended two partition GPT set-up 
+(plus a BIOS Boot partition), ready to use with `glim.sh` itself.  I've tried to 
+make it safe, so for example it shouldn't delete any partitions, only create new 
+ones... And in the event of any errors, the script should stop rather than risk 
+doing anything wrong. HOWEVER, it is still a very new script, which likely 
+contains bugs, especially on systems different to my own, so please let me know 
+about any problems you experience.  You use this script entirely at your own 
+risk.  If it formats your entire computer, then that is your problem.  So please 
+make sure you have a recent backup before using it.
 
 
 Installation

--- a/format_empty_disk.sh
+++ b/format_empty_disk.sh
@@ -77,7 +77,7 @@ trap "echo 'ERROR: Script did not finished partitioning.'" EXIT
 set -x
 #sudo sgdisk --zap-all $Disk	# erase any existing partition information from HD
 sudo sgdisk --mbrtogpt $Disk	# use GPT not MBR
-sudo sgdisk --clear $Disk		# wipe any previous partition
+#sudo sgdisk --clear $Disk		# wipe any previous partition
 #sudo partprobe $Disk			# request the OS re-reads the partition table
 sudo blockdev --rereadpt $Disk	# request the OS re-reads the partition table', and errors if a partition is already mounted on the disk
 

--- a/format_empty_disk.sh
+++ b/format_empty_disk.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e		# exit on error
+#set -v		# print script lines to be executed
+#set -x		# print commands being executed
+
+for Cmd in fdisk lsblk sgdisk blockdev partprobe; do
+	if [ -z "$(which $Cmd | cat)" ]; then
+		echo "ERROR: This script needs the '$Cmd' command, please install it."
+		exit 1
+	fi
+done
+
+GlimSize=100M
+BiosBootSize=1M
+
+echo "Please read the 'README.md' documentation before using this script."
+echo ""
+echo "WARNING: This script will format a chosen empty hard disk with GLIM's recommended set-up.  Although I've tried to be careful, a bug could potentially wipe your whole computer.  So make sure you have a recent backed-up before executing this script."
+echo ""
+echo 'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+echo ""
+read -p "If you have read, understood & fully accepted the above, then please enter 'yes' in capitals: " Ans
+if [ "$Ans" != "YES" ]; then
+	echo "Script cancelled by user."
+	exit 0
+fi
+echo ""
+
+# Specify disk to overwrite
+read -p "Please enter path of disk to overwrite: " Disk
+if [ -z "$Disk" ]; then echo "Script cancelled by user."; exit 0; fi
+echo ""
+
+# Check that disk is a block device
+#if [[ ! "$Disk" == /dev/* ]]; then
+#	echo "ERROR: '$Disk' does not start with /dev/"
+#	exit 1
+#fi
+Devices="$(lsblk -o name -lpn --nodeps -e7)"
+if [ -z "$(echo "$Devices" | grep "^${Disk}$")" ]; then
+	echo "ERROR: '$Disk' is not a known block device:"
+	echo "$Devices"
+	exit 1
+fi
+
+# Check not overwriting the boot disk (but this is not foolproof)
+if [[ "$(awk '$1 ~ /^\/dev\// && $2 == "/boot" { print $1 }' /proc/self/mounts)" == ${Disk}* ]]; then
+	echo "ERROR: $Disk is the boot disk."
+	exit 1
+fi
+
+## Check that disk has no mounted partitions
+#if [ -n "$(mount | grep ^$Disk | cat)" ]; then
+#	echo "ERROR: $Disk is has mounted partitions."
+#	exit 1
+#fi
+
+# Check that disk has no partitions
+set -x
+Partitions="$(sudo fdisk -l $Disk | sed '1,/^$/d')"
+set +x
+if [ "$(echo "$Partitions" | wc -l)" -gt 1 ]; then
+	echo "ERROR: $Disk is not empty, it has partitions:"
+	echo "$Partitions"
+	exit 1
+fi
+
+# Confirm using the correct disk
+sudo sgdisk --print $Disk
+echo ""
+read -p "Is this the correct disk to overwrite? [y/N] " Ans
+if [[ "$Ans" != "y" && "$Ans" != "Y" ]]; then echo "Script cancelled by user."; exit 1; fi
+echo ""
+
+# Create partitions on disk
+trap "echo 'ERROR: Script did not finished partitioning.'" EXIT
+set -x
+#sudo sgdisk --zap-all $Disk	# erase any existing partition information from HD
+sudo sgdisk --mbrtogpt $Disk	# use GPT not MBR
+sudo sgdisk --clear $Disk		# wipe any previous partition
+#sudo partprobe $Disk			# request the OS re-reads the partition table
+sudo blockdev --rereadpt $Disk	# request the OS re-reads the partition table', and errors if a partition is already mounted on the disk
+
+sudo sgdisk --new=1:0:+$GlimSize $Disk # use first 100MB
+sudo sgdisk --new=3:-${BiosBootSize}:0 --typecode=3:ef02 --partition-guid=3:21686148-6449-6E6F-744E-656564454649 $Disk # use last 1MB for BIOS Boot partition needed by GRUB
+sudo sgdisk --new=2:0:0 $Disk # use rest of space
+#sudo sgdisk --typecode=1:8300 --typecode=2:8300 $Disk
+#sudo sgdisk --change-name=1:GLIM $Disk	# This is just a human-readable label, displayed by --print under the Name column
+#sudo sgdisk --change-name=2:GLIMISO $Disk
+sudo sgdisk --change-name=3:"BIOS Boot" $Disk
+sudo partprobe $Disk	# ensure kernel is using the new partition table, before we format partitions
+set +x
+
+echo "Waiting a few seconds... "
+sleep 2		# give OS time to auto-mount new partitions, if they happened to start at same location as a previously-deleted partition
+sudo umount ${Disk}1 2>/dev/null | cat
+sudo umount ${Disk}2 2>/dev/null | cat
+sudo umount ${Disk}3 2>/dev/null | cat
+
+# Format partitions
+trap "echo 'ERROR: Script did not finished formatting.'" EXIT
+set -x
+sudo mkfs.fat -F 32 -n GLIM ${Disk}1
+sudo mkfs.ext4 -L GLIMISO ${Disk}2
+set +x
+
+# Try to get OS to mount new partitions
+sleep 1
+sudo partprobe $Disk
+#sudo blockdev --rereadpt $Disk
+
+# Report success
+echo ""
+echo "Successfully finished creating the partitions needed by GLIM."
+echo "Ensure ${Disk}1 (GLIM) & ${Disk}2 (GLIMISO) are mounted before running the 'glim.sh' script."
+trap "" EXIT

--- a/glim.sh
+++ b/glim.sh
@@ -70,7 +70,7 @@ if ! grep -q -w ${USBDEV1} /proc/mounts; then
   echo "ERROR: ${USBDEV1} isn't mounted"
   exit 1
 fi
-USBMNT=`grep -w ${USBDEV1} /proc/mounts | cut -d ' ' -f 2`
+USBMNT="$(grep -w ${USBDEV1} /proc/mounts | cut -d ' ' -f 2)"
 if [[ -z "$USBMNT" ]]; then
   echo "ERROR: Couldn't find mount point for ${USBDEV1}"
   exit 1
@@ -130,17 +130,17 @@ fi
 # Install GRUB2
 if [[ $BIOS == true ]]; then
   GRUB_TARGET="--target=i386-pc"
-  echo "Running ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory=${USBMNT}/boot ${USBDEV} (with sudo) ..."
-  sudo ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory=${USBMNT}/boot ${USBDEV}
+  echo "Running ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory '${USBMNT}/boot' ${USBDEV} (with sudo) ..."
+  sudo          ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory "${USBMNT}/boot" ${USBDEV}
   if [[ $? -ne 0 ]]; then
       echo "ERROR: ${GRUB2_INSTALL} returned with an error exit status."
       exit 1
   fi
 fi
 if [[ $EFI == true ]]; then
-  GRUB_TARGET="--target=x86_64-efi --efi-directory=${USBMNT} --removable"
-  echo "Running ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory=${USBMNT}/boot ${USBDEV} (with sudo) ..."
-  sudo ${GRUB2_INSTALL} ${GRUB_TARGET} --boot-directory=${USBMNT}/boot ${USBDEV}
+  GRUB_TARGET="--target=x86_64-efi --removable"
+  echo "Running ${GRUB2_INSTALL} ${GRUB_TARGET} --efi-directory '${USBMNT}' --boot-directory '${USBMNT}/boot' ${USBDEV} (with sudo) ..."
+  sudo          ${GRUB2_INSTALL} ${GRUB_TARGET} --efi-directory "${USBMNT}" --boot-directory "${USBMNT}/boot" ${USBDEV}
   if [[ $? -ne 0 ]]; then
     echo "ERROR: ${GRUB2_INSTALL} returned with an error exit status."
     exit 1
@@ -155,16 +155,16 @@ else
 fi
 
 # Copy GRUB2 configuration
-echo "Running rsync -rt --delete --exclude=i386-pc --exclude=x86_64-efi --exclude=fonts ${GRUB2_CONF}/ ${USBMNT}/boot/${GRUB2_DIR} ..."
-${CMD_PREFIX} rsync -rt --delete --exclude=i386-pc --exclude=x86_64-efi --exclude=fonts ${GRUB2_CONF}/ ${USBMNT}/boot/${GRUB2_DIR}
+echo "Running rsync -rt --delete --exclude=i386-pc --exclude=x86_64-efi --exclude=fonts -- ${GRUB2_CONF}/ '${USBMNT}/boot/${GRUB2_DIR}' ..."
+${CMD_PREFIX} rsync -rt --delete --exclude=i386-pc --exclude=x86_64-efi --exclude=fonts -- ${GRUB2_CONF}/ "${USBMNT}/boot/${GRUB2_DIR}"
 if [[ $? -ne 0 ]]; then
   echo "ERROR: the rsync copy returned with an error exit status."
   exit 1
 fi
 
 # Be nice and pre-create the directory, and mention it
-[[ -d ${USBMNT}/boot/iso ]] || ${CMD_PREFIX} mkdir ${USBMNT}/boot/iso
-echo "GLIM installed! Time to populate the boot/iso/ sub-directories."
+[[ -d "${USBMNT}/boot/iso" ]] || ${CMD_PREFIX} mkdir "${USBMNT}/boot/iso"
+echo "GLIM installed! Time to populate the '${USBMNT}/boot/iso' sub-directories."
 
 # Now also pre-create all supported sub-directories since empty are ignored
 args=(
@@ -173,6 +173,6 @@ args=(
 )
 
 for DIR in $(sed "${args[@]}" "$(dirname "$0")"/README.md); do
-  [[ -d ${USBMNT}/boot/iso/${DIR} ]] || ${CMD_PREFIX} mkdir ${USBMNT}/boot/iso/${DIR}
+  [[ -d "${USBMNT}/boot/iso/${DIR}" ]] || ${CMD_PREFIX} mkdir "${USBMNT}/boot/iso/${DIR}"
 done
 

--- a/glim.sh
+++ b/glim.sh
@@ -147,7 +147,7 @@ if [[ $BIOS == true ]]; then
     echo "y"
     
     if [[ "$PartType" == "gpt" ]]; then
-		BiosBootPartWarning="(Grub needs a BIOS Boot Partition) "
+      BiosBootPartWarning="(Grub needs a BIOS Boot Partition) "
     fi
     read -n 1 -s -p "Also install for standard BIOS? $BiosBootPartWarning(y/N) " BIOS
     if [[ "$BIOS" == "y" || "$BIOS" == "Y" ]]; then

--- a/glim.sh
+++ b/glim.sh
@@ -30,7 +30,7 @@ if [[ ! -f ${GRUB2_CONF}/grub.cfg ]]; then
 fi
 
 #
-# Find GLIM device (use the first if multiple found, you've asked for trouble!)
+# Find GLIM device
 #
 
 # Sanity check : blkid command
@@ -38,11 +38,14 @@ if ! which blkid &>/dev/null; then
   echo "ERROR: blkid command not found."
   exit 1
 fi
-USBDEV1=`blkid -L GLIM | head -n 1`
+USBDEV1=`blkid -L GLIM`
 
 # Sanity check : we found one partition to use with matching label
 if [[ -z "$USBDEV1" ]]; then
   echo "ERROR: no partition found with label 'GLIM', please create one."
+  exit 1
+elif [[ "$(echo "$USBDEV1" | wc -l)" -gt 1 ]]; then
+  echo "ERROR: multiple partitions found with label 'GLIM', please disconnect/rename the unwanted ones."
   exit 1
 fi
 echo "Found partition with label 'GLIM' : ${USBDEV1}"

--- a/glim.sh
+++ b/glim.sh
@@ -95,6 +95,7 @@ if [[ $? -ne 0 ]]; then
 elif [[ "$PartType" == "gpt" ]]; then
   echo "The ${USBDEV} block device uses GPT, which means you can only install for EFI (not BIOS) unless it has a 1MB BIOS Boot partition for Grub."
 else
+  PartType="dos"	# Ensure script behaves sensibly if fdisk doesn't output "gpt" or "dos"
   echo "The ${USBDEV} block device uses GPT, which means Grub can install for both EFI & BIOS."
 fi
 
@@ -200,3 +201,4 @@ for DIR in $(sed "${args[@]}" "$(dirname "$0")"/README.md); do
   [[ -d "${USBMNT}/boot/iso/${DIR}" ]] || ${CMD_PREFIX} mkdir "${USBMNT}/boot/iso/${DIR}"
 done
 
+echo "Finished!"

--- a/glim.sh
+++ b/glim.sh
@@ -50,16 +50,19 @@ elif [[ "$(echo "$USBDEV1" | wc -l)" -gt 1 ]]; then
 fi
 echo "Found partition with label 'GLIM' : ${USBDEV1}"
 
-# Sanity check : our partition is the first and only one on the block device
+# Sanity check : our partition is the first one on the block device
+if [[ ! "${USBDEV1}" == *[a-z]1 ]]; then
+  echo "ERROR: $USBDEV1 is not the first partition on the block device."
+  exit 1
+fi
 USBDEV=${USBDEV1%1}
 if [[ ! -b "$USBDEV" ]]; then
   echo "ERROR: ${USBDEV} block device not found."
   exit 1
 fi
 echo "Found block device where to install GRUB2 : ${USBDEV}"
-if [[ `ls -1 ${USBDEV}* | wc -l` -ne 2 ]]; then
-  echo "ERROR: ${USBDEV1} isn't the only partition on ${USBDEV}"
-  exit 1
+if [[ `ls -1 ${USBDEV}* | wc -l` -gt 2 ]]; then
+  echo "WARNING: There is more than one partition on ${USBDEV}"
 fi
 
 # Sanity check : our partition is mounted

--- a/glim.sh
+++ b/glim.sh
@@ -130,7 +130,7 @@ elif [[ "$PartType" == "gpt" ]]; then
   echo "The ${USBDEV} block device uses GPT, which means you can only install for EFI (not BIOS) unless it has a 1MB BIOS Boot partition for Grub.  GLIM needs this after the GLIMISO partition (if there is one)."
 else
   PartType="dos"	# Ensure script behaves sensibly if fdisk doesn't output "gpt" or "dos"
-  echo "The ${USBDEV} block device uses GPT, which means Grub can install for both EFI & BIOS."
+  echo "The ${USBDEV} block device uses MBR, which means Grub can install for both EFI & BIOS."
 fi
 
 #

--- a/glim.sh
+++ b/glim.sh
@@ -94,9 +94,9 @@ fi
 if [[ $BIOS == true ]]; then
   # Set the target
   read -n 1 -s -p "Install for EFI in addition to standard BIOS? (Y/n) " EFI
-  if [[ "$EFI" == "n" ]]; then
-      EFI=false
-      echo "n"
+  if [[ "$EFI" == "n" || "$EFI" == "N" ]]; then
+    EFI=false
+    echo "n"
   else
     EFI=true
     echo "y"
@@ -119,12 +119,13 @@ fi
 #
 
 # Sanity check : human will read the info and confirm
-read -n 1 -s -p "Ready to install GLIM. Continue? (Y/n) " PROCEED
-if [[ "$PROCEED" == "n" ]]; then
+echo ""
+read -n 1 -s -p "Ready to install GLIM. Continue? (y/N) " PROCEED
+if [[ "$PROCEED" == "y" || "$PROCEED" == "Y" ]]; then
+  echo "y"
+else
   echo "n"
   exit 2
-else
-  echo "y"
 fi
 
 # Install GRUB2

--- a/glim.sh
+++ b/glim.sh
@@ -226,7 +226,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Be nice and pre-create the directory, and mention it
-[[ -d "${USBMNTISO}/iso" ]] || ${ISOCMD_PREFIX} mkdir "${USBMNTISO}/iso"
+[[ -d "${USBMNTISO}/iso" ]] || ${ISOCMD_PREFIX} mkdir -p "${USBMNTISO}/iso"
 echo "GLIM installed! Time to populate the '${USBMNTISO}/iso' sub-directories."
 
 # Now also pre-create all supported sub-directories since empty are ignored
@@ -236,7 +236,7 @@ args=(
 )
 
 for DIR in $(sed "${args[@]}" "$(dirname "$0")"/README.md); do
-  [[ -d "${USBMNTISO}/iso/${DIR}" ]] || ${ISOCMD_PREFIX} mkdir "${USBMNTISO}/iso/${DIR}"
+  [[ -d "${USBMNTISO}/iso/${DIR}" ]] || ${ISOCMD_PREFIX} mkdir -p "${USBMNTISO}/iso/${DIR}"
 done
 
 echo "Finished!"

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -5,6 +5,7 @@
 # WHERE IT MATTERS. In particular `for .. in "$@"` loops should be wrapped in
 # `if [ $# -gt 0 ] .. fi`
 
+# Enable reg-ex
 insmod regexp
 
 # Required for GUI and to prevent "No video mode set" error
@@ -17,17 +18,32 @@ set gfxpayload=keep
 # Enable GUI
 terminal_output gfxterm
 
+# Set how menu looks
 loadfont unicode
-
 insmod png
 set theme=${prefix}/themes/invader/theme.txt
 
-set isopath=/boot/iso
+# Find UUID of GRUB's boot partition
 probe --set rootuuid --fs-uuid $root
+
+# Detect which partition the ISOs are stored on
+set isopath=/iso
+insmod part_msdos
+insmod part_gpt
+insmod ext2
+insmod ntfs
+if [ -e (hd0,gpt2)${isopath} ]; then
+  set root="(hd0,gpt2)"
+elif [ -e (hd0,msdos2)${isopath} ]; then
+  set root="(hd0,msdos2)"
+#else
+#  set isopath=/boot/iso
+fi
+
 # Required to have these available in other configfile files
-export isopath
 export rootuuid
 export theme
+export isopath
 
 function use {
   echo "Using $1 ..."

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -18,6 +18,9 @@ set gfxpayload=keep
 # Enable GUI
 terminal_output gfxterm
 
+# Welcome msg
+echo "Booting GLIM"
+
 # Set how menu looks
 loadfont unicode
 insmod png
@@ -30,19 +33,26 @@ probe --set rootuuid --fs-uuid $root
 set isopath=/iso
 insmod part_msdos
 insmod part_gpt
+insmod exfat
 insmod ext2
 insmod ntfs
 #insmod btrfs
 #insmod lvm
-for i in 0 1 2 3 4 5 6 7 8 9; do
-  if [ -e (hd0,gpt$i)${isopath} ]; then
-    set root="(hd0,gpt$i)"
+insmod regexp
+echo "Boot partition: ${root}"
+#set hdnum=0
+regexp --set 1:hdnum "^hd([0-9]+),.*" "${root}"
+echo "Boot disk: hd${hdnum}"
+for pnum in 0 1 2 3 4 5 6 7 8 9; do
+  if [ -e     (hd${hdnum},gpt${pnum})${isopath} ]; then
+    set root="(hd${hdnum},gpt${pnum})"
     break
-  elif [ -e (hd0,msdos$i)${isopath} ]; then
-    set root="(hd0,msdos$i)"
+  elif [ -e   (hd${hdnum},msdos${pnum})${isopath} ]; then
+    set root="(hd${hdnum},msdos${pnum})"
     break
   fi
 done
+echo "ISO partition: ${root}"
 
 # Required to have these available in other configfile files
 export rootuuid

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -32,6 +32,8 @@ insmod part_msdos
 insmod part_gpt
 insmod ext2
 insmod ntfs
+#insmod btrfs
+#insmod lvm
 for i in 0 1 2 3 4 5 6 7 8 9; do
   if [ -e (hd0,gpt$i)${isopath} ]; then
     set root="(hd0,gpt$i)"

--- a/grub2/grub.cfg
+++ b/grub2/grub.cfg
@@ -32,13 +32,15 @@ insmod part_msdos
 insmod part_gpt
 insmod ext2
 insmod ntfs
-if [ -e (hd0,gpt2)${isopath} ]; then
-  set root="(hd0,gpt2)"
-elif [ -e (hd0,msdos2)${isopath} ]; then
-  set root="(hd0,msdos2)"
-#else
-#  set isopath=/boot/iso
-fi
+for i in 0 1 2 3 4 5 6 7 8 9; do
+  if [ -e (hd0,gpt$i)${isopath} ]; then
+    set root="(hd0,gpt$i)"
+    break
+  elif [ -e (hd0,msdos$i)${isopath} ]; then
+    set root="(hd0,msdos$i)"
+    break
+  fi
+done
 
 # Required to have these available in other configfile files
 export rootuuid


### PR DESCRIPTION
Like many people, I've been desperately looking for something to replace Ventoy (due to it's huge number of mystery binary blobs, opaque build process & foreign origin), and GLIM came _really_ close - it just didn't support ISOs >4GB.  I've been able to solve that major limitation by adding support for a second partition that uses (say) Ext4.  I've tried to keep to the style of your source code, made my changes as small as possible, and split the changes into small commits so you easily see what I've done & why.  

I have also made some other small improvements which I hope you won't object to:
* Detect if GPT (rather than MBR) is used, and warn that GRUB requires an extra BIOS Boot Partition for the non-EFI case.
* Made BIOS installation optional if you pick EFI, in case you don't have a BIOS Boot Partition.
* When using a single partition, the ISO folder has been moved from boot/iso/ to just iso/, so it's in the same location whether you use one or two partitions (simplifies documentation & code), as well as IMHO being easier for newbies to find.
* Made "Ready to install GLIM" default to "No", so you can't accidentally proceed if you are just pressing enter without reading the prompts.
* Made the Y/N prompts case insensitive.
* Warn rather than error if there are more than 2 partitions on the block device.  (My use case is having bootable ISOs on my external backup HD, so I can boot & restore all from one device - Ventoy allows that sort of thing.  Plus the BIOS Boot Partition.)
* Halt if there are multiple GLIM partitions, since it seems asking for trouble if just randomly pick one!
* Added quoting so it can handle the spaces in $USBMNT, just in case of weird systems.

I've tested all these changes as much as I can, on a real physical machine (no VM).