### PR TITLE
Support new ISO layout in Fedora 42, remove dependency on filename

### DIFF
--- a/grub2/inc-fedora.cfg
+++ b/grub2/inc-fedora.cfg
@@ -4,24 +4,43 @@ function add_menu {
 
   regexp \
     --set 1:isoname \
-    --set 2:variant \
-    --set 3:purpose \
-    --set 4:arch \
-    --set 5:version \
-    "^${isopath}/fedora/(Fedora-([^-]+)-(Live|netinst)-([^-]+)-([^-]+)-[^-]+\.iso)\$" "${isofile}"
-  menuentry "Fedora ${version} ${arch} ${variant} ${purpose}" "${isofile}" "${isoname}" "${purpose}" --class fedora {
+    --set 2:title \
+    "^${isopath}/fedora/((.*)\.iso)\$" "${isofile}"
+  menuentry "${title}" "${isofile}" "${isoname}" --class fedora {
     set isofile=$2
     set isoname=$3
-    set purpose=$4
     use "${isoname}"
     loop $isofile
     probe --set isolabel --label (loop)
-    if [ "${purpose}" == 'netinst' ]; then
+
+    if [ ! -d "(loop)/LiveOS" ]; then
+      # netinst ISO
       linux (loop)/images/pxeboot/vmlinuz inst.stage2=hd:LABEL=${isolabel} iso-scan/filename=${isofile}
+      initrd (loop)/images/pxeboot/initrd.img
     else
-      linux (loop)/images/pxeboot/vmlinuz root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
+      # live ISO... is it old-style or new-style?
+      set linux_path=""
+      if [ -d "(loop)/images/pxeboot" ]; then
+        # old-style (Fedora live <=41, and netinst)
+        set linux_path="(loop)/images/pxeboot/vmlinuz"
+        set initrd_path="(loop)/images/pxeboot/initrd.img"
+      else
+        # new-style (Fedora live >=42), linux directory depends on the arch
+        for arch in "x86_64" "aarch64"; do
+          if [ -d "(loop)/boot/${arch}" ]; then
+            set linux_path="(loop)/boot/${arch}/loader/linux"
+            set initrd_path="(loop)/boot/${arch}/loader/initrd"
+            break
+          fi
+        done
+      fi
+      if [ -z "${linux_path}" ]; then
+        echo "Could not find kernel in ${isofile}"
+      else
+        linux "${linux_path}" root=live:CDLABEL=${isolabel} rd.live.image iso-scan/filename=${isofile}
+        initrd "${initrd_path}"
+      fi
     fi
-    initrd (loop)/images/pxeboot/initrd.img
   }
 }
 


### PR DESCRIPTION
In the Fedora 42 live ISOs:

a) The filesystem layout has changed, so the kernel and initrd no longer exist in the location where the GRUB config previously expected them
b) The structure of the ISO filename has changed so the previous regex no longer parses it correctly

This change no longer attempts to parse the structure of the filename or infer anything about the ISO layout from it: instead it sets up the boot according to the directory structure it finds in the ISO.